### PR TITLE
Adding BCC fields to contact forms.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ An email sent with the above form might result in the following message:
     Cathy Chino
 
 
+### Adding BCC recipients
+
+You can add additional recipients to a form by using the following Twig function/filter. The example code below will create a hidden input field in your form which contains the encrypted BCC recipient. You can add as many BCC recipients as you wish.
+
+    {{ 'my@email.com' | contact_recipient }}
+
+
 ### File attachments
 
 If you would like your contact form to accept file attachments, follow these steps:

--- a/contactform/ContactFormPlugin.php
+++ b/contactform/ContactFormPlugin.php
@@ -39,4 +39,11 @@ class ContactFormPlugin extends BasePlugin
 			'settings' => $this->getSettings()
 		));
 	}
+
+    public function hookAddTwigExtension()
+    {
+        Craft::import('plugins.contactform.twigextensions.RecipientTwigExtension');
+        
+        return new RecipientTwigExtension();
+    }
 }

--- a/contactform/controllers/ContactFormController.php
+++ b/contactform/controllers/ContactFormController.php
@@ -152,6 +152,24 @@ class ContactFormController extends BaseController
 			$email->subject   = $subject;
 			$email->body      = $message->message;
 
+
+			// Any BCC recipients?
+			$recipients = craft()->request->getPost('recipients');
+			
+			if ($recipients)
+			{
+				$bcc = array();
+
+				foreach ($recipients as $recipient)
+				{
+					$recipient_email = \Yii::app()->getSecurityManager()->decrypt(base64_decode($recipient)); 
+					$bcc[] = array('email' => $recipient_email);
+				}
+
+				$email->bcc = $bcc;
+			}
+			
+
 			$attachment = \CUploadedFile::getInstanceByName('attachment');
 
 			if ($attachment)

--- a/contactform/twigextensions/RecipientTwigExtension.php
+++ b/contactform/twigextensions/RecipientTwigExtension.php
@@ -1,0 +1,35 @@
+<?php
+namespace Craft;
+
+class RecipientTwigExtension extends \Twig_Extension
+{
+    protected $env;
+    
+    public function getName()
+    {
+        return 'Adds additional recipients to contact form';
+    }
+    
+    public function getFilters()
+    {
+        return array('contact_recipient' => new \Twig_Filter_Method($this, 'add_recipient', array('is_safe' => array('html'))));
+    }
+    
+    public function getFunctions()
+    {
+        return array('contact_recipient' => new \Twig_Function_Method($this, 'add_recipient', array('is_safe' => array('html'))));
+    }
+    
+    public function initRuntime(\Twig_Environment $env)
+    {
+        $this->env = $env;
+    }
+    
+    public function add_recipient($email)
+    {
+
+        $email = '<input type="hidden" name="recipients[]" value="' . base64_encode(\Yii::app()->getSecurityManager()->encrypt($email)) . '">'; 
+
+        return $email;
+    }
+}


### PR DESCRIPTION
I needed to change the email recipients for different forms on a client's website. So I've added BCC fields as an option to overcome the current limitation.

Forms will always send to the default email as set in settings, but you also also BCC to other email addresses.

I've encrypted the fields so there should be no fear of abuse.
