### PR TITLE
Allow multiple attachments

### DIFF
--- a/contactform/controllers/ContactFormController.php
+++ b/contactform/controllers/ContactFormController.php
@@ -30,7 +30,7 @@ class ContactFormController extends BaseController
 		$message->fromEmail  = craft()->request->getPost('fromEmail');
 		$message->fromName	 = craft()->request->getPost('fromName');
 		$message->subject    = craft()->request->getPost('subject');
-		$message->attachment = \CUploadedFile::getInstanceByName('attachment');
+		$message->attachment = \CUploadedFile::getInstancesByName('attachment');
 
 		// Set the message body
 		$postedMessage = craft()->request->getPost('message');

--- a/contactform/services/ContactFormService.php
+++ b/contactform/services/ContactFormService.php
@@ -48,7 +48,10 @@ class ContactFormService extends BaseApplicationComponent
 
 					if ($message->attachment)
 					{
-						$email->addAttachment($message->attachment->getTempName(), $message->attachment->getName(), 'base64', $message->attachment->getType());
+						foreach ($message->attachment as $attachment)
+						{
+							$email->addAttachment($attachment->getTempName(), $attachment->getName(), 'base64', $attachment->getType());
+						}
 					}
 
 					craft()->email->sendEmail($email);


### PR DESCRIPTION
Allow multiple attachments to be sent to the contact form, as per #31, e.g.:
```
<input type="file" name="attachment[]" multiple>
```
Unfortunately this requires all attachment inputs (wether single or multiple files) to be named `attachment[]`. 
Not sure how to fix this elegantly, so suggestions would be welcomed.