### PR TITLE
Allow "toEmail" override

### DIFF
--- a/contactform/controllers/ContactFormController.php
+++ b/contactform/controllers/ContactFormController.php
@@ -27,6 +27,7 @@ class ContactFormController extends BaseController
 		$message = new ContactFormModel();
 		$savedBody = false;
 
+		$message->toEmail    = craft()->request->getPost('toEmail');
 		$message->fromEmail  = craft()->request->getPost('fromEmail');
 		$message->fromName	 = craft()->request->getPost('fromName');
 		$message->subject    = craft()->request->getPost('subject');

--- a/contactform/models/ContactFormModel.php
+++ b/contactform/models/ContactFormModel.php
@@ -6,6 +6,7 @@ class ContactFormModel extends BaseModel
 	protected function defineAttributes()
 	{
 		return array(
+			'toEmail'    => array(AttributeType::String, 'label' => 'Recipient Email'),
 			'fromName'   => array(AttributeType::String, 'label' => 'Your Name'),
 			'fromEmail'  => array(AttributeType::Email,  'required' => true, 'label' => 'Your Email'),
 			'message'    => array(AttributeType::String, 'required' => true, 'label' => 'Message'),

--- a/contactform/services/ContactFormService.php
+++ b/contactform/services/ContactFormService.php
@@ -17,7 +17,7 @@ class ContactFormService extends BaseApplicationComponent
 	{
 		$settings = craft()->plugins->getPlugin('contactform')->getSettings();
 
-		if (!$settings->toEmail)
+		if (!$message->toEmail && !$settings->toEmail)
 		{
 			throw new Exception('The "To Email" address is not set on the plugin’s settings page.');
 		}
@@ -31,7 +31,8 @@ class ContactFormService extends BaseApplicationComponent
 		{
 			if (!$event->fakeIt)
 			{
-				$toEmails = ArrayHelper::stringToArray($settings->toEmail);
+				$to = ($message->toEmail ? $message->toEmail : $settings->toEmail);
+				$toEmails = ArrayHelper::stringToArray($to);
 
 				foreach ($toEmails as $toEmail)
 				{


### PR DESCRIPTION
Added a `toEmail` attribute to the `ContactFormModel`.

This allows the form to set a new destination email address, which will _override_ whatever has been established in the plugin's settings.

**EXAMPLE USAGE:**

    <input type="hidden" name="toEmail" value="override-email@example.com">

And just as you can in the plugin's settings, you can specify multiple email addresses by separating them with commas.