### PR TITLE
Allow users to set a success message

### DIFF
--- a/contactform/ContactFormPlugin.php
+++ b/contactform/ContactFormPlugin.php
@@ -85,6 +85,9 @@ class ContactFormPlugin extends BasePlugin
 			'prependSubject'   => AttributeType::String,
 			'allowAttachments' => AttributeType::Bool,
 			'honeypotField'    => AttributeType::String,
+			'successMessage'   => array(AttributeType::String,
+			                            'default' => 'Your message has been sent.',
+			                            'required' => true),
 		);
 	}
 }

--- a/contactform/controllers/ContactFormController.php
+++ b/contactform/controllers/ContactFormController.php
@@ -128,7 +128,7 @@ class ContactFormController extends BaseController
 						$_POST['redirect'] = $successRedirectUrl;
 					}
 
-					craft()->userSession->setNotice('Your message has been sent.');
+					craft()->userSession->setNotice($settings->successMessage);
 					$this->redirectToPostedUrl($message);
 				}
 			}

--- a/contactform/templates/_settings.html
+++ b/contactform/templates/_settings.html
@@ -48,3 +48,11 @@
 	errors:       settings.getErrors('honeypotField')
 }) }}
 
+{{ forms.textField({
+	label:        "Success Message"|t,
+	id:           "successMessage",
+	name:         "successMessage",
+	instructions: "The message displayed after successfully sending a message."|t,
+	value:        settings.successMessage,
+	errors:       settings.getErrors('successMessage')
+}) }}


### PR DESCRIPTION
Hi,

It would be really useful if the Success Message were a user setting, because sometimes I need to say something more than just "Your message has been sent." For example, I also need to say that the person sending the message will be contacted as soon as possible, and I need to say it in a different language.

Adding a setting seems more flexible than adding a translation. And with the default setting it shouldn't break anything for existing users (hopefully).

Please let me know what you think of this change.

Thanks in advance.


Cheers,

Tom