### PR TITLE
Pass settings to ContactFormEvent allowing modification before sending

### DIFF
--- a/contactform/services/ContactFormService.php
+++ b/contactform/services/ContactFormService.php
@@ -24,7 +24,7 @@ class ContactFormService extends BaseApplicationComponent
 
 		// Fire an 'onBeforeSend' event
 		Craft::import('plugins.contactform.events.ContactFormEvent');
-		$event = new ContactFormEvent($this, array('message' => $message));
+		$event = new ContactFormEvent($this, array('message' => $message, 'settings' => $settings));
 		$this->onBeforeSend($event);
 
 		if ($event->isValid)


### PR DESCRIPTION
By passing the settings to the `ContactFormEvent` it is possible for a developer to add extra to email addresses without exposing them in the template.

I have come across a use case where there are multiple points of contact on a website and each contact form has different recipients. By adding settings to the event a developer could easily achieve this.