### PR TITLE
don't validate settings if in read-only mode

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -47,7 +47,11 @@ class Plugin extends \craft\base\Plugin
     {
         // Get and pre-validate the settings
         $settings = $this->getSettings();
-        $settings->validate();
+
+        $readOnly = !Craft::$app->getConfig()->getGeneral()->allowAdminChanges;
+        if (!$readOnly) {
+            $settings->validate();
+        }
 
         // Get the settings that are being defined by the config file
         $overrides = Craft::$app->getConfig()->getConfigFromFile(strtolower($this->handle));


### PR DESCRIPTION
### Description
When `allowAdminChanges` is set to `false`, don’t validate the settings.

I’m not bumping the cms requirement for this one, as this change won’t break anything if the cms version is below 5.6.0.


### Related issues
https://github.com/craftcms/cms/pull/16265
